### PR TITLE
Fix crash that occurs because persistentContainer isn't established …

### DIFF
--- a/019 DadJokes/macOS/DadJokes/AppDelegate.swift
+++ b/019 DadJokes/macOS/DadJokes/AppDelegate.swift
@@ -18,7 +18,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         // Create the SwiftUI view and set the context as the value for the managedObjectContext environment keyPath.
         // Add `@Environment(\.managedObjectContext)` in the views that will need the context.
-        let contentView = ContentView().environment(\.managedObjectContext, persistentContainer.viewContext)
+        let context = persistentContainer.viewContext
+        let contentView = ContentView().environment(\.managedObjectContext, context)
 
         // Create the window and set the content view. 
         window = NSWindow(


### PR DESCRIPTION
…quite early enough.

> 2019-09-29 21:39:44.531232-0700 DadJokes[7496:1229922] [error] error: No NSEntityDescriptions in any model claim the NSManagedObject subclass 'Joke' so +entity is confused.  Have you loaded your NSManagedObjectModel yet ?
> CoreData: error: No NSEntityDescriptions in any model claim the NSManagedObject subclass 'Joke' so +entity is confused.  Have you loaded your NSManagedObjectModel yet ?
> 2019-09-29 21:39:44.531341-0700 DadJokes[7496:1229922] [error] error: +[Joke entity] Failed to find a unique match for an NSEntityDescription to a managed object subclass
> CoreData: error: +[Joke entity] Failed to find a unique match for an NSEntityDescription to a managed object subclass
2019-09-29 21:39:44.631101-0700 DadJokes[7496:1229922] executeFetchRequest:error: A fetch request must have an entity.